### PR TITLE
Update 'debug' dependency (2.6.8 to ^2.6.8)

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,6 @@
     "tape": "^4.7.0"
   },
   "dependencies": {
-    "debug": "2.6.8"
+    "debug": "^2.6.8"
   }
 }


### PR DESCRIPTION
There is a vulnerability in debug@2.6.8. See here for details: https://nodesecurity.io/advisories/534
The pull request adds '^' to the dependency version specification to enable debug@2.6.9 to be used.